### PR TITLE
Map additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv
+venv/

--- a/Dashboard_v1.2.py
+++ b/Dashboard_v1.2.py
@@ -1,7 +1,11 @@
 import pandas as pd
 import plotly.express as px
 import plotly.io as pio
+from plotly import graph_objects as go
+import numpy as np
 from dash import Dash, dcc, html, Input, Output
+import json
+
 
 pio.renderers.default = 'browser'
 app = Dash(__name__)
@@ -32,6 +36,15 @@ app.layout = html.Div([
 
     html.Div([
         dcc.Graph(id='the_graph'),
+        html.H4( # added this to display link to info about country relations
+            id='hover_link',
+            style={
+                'color': '#9bb3ce',
+                'fontFamily': 'Open Sans, arial',
+                'textAlign': 'center',
+                'marginTop': 0
+            }
+        ),
         dcc.Graph(id='the_graph2')
     ]),
 ])
@@ -62,16 +75,51 @@ def set_metal_options(selected_metal):
 )
 def update_graph(metal_value, subcategory):
     dff = df[df['Metal'] == metal_value]
-    choropleth = px.choropleth(
-        locations=dff['name'],
-        locationmode="country names",
-        color=dff['Category'],
-        color_discrete_map=color_dictionary,
-        hover_name=dff["Percentage"],
-        title='Import Source Countries',
-        scope="world"
-    )
+  
+    # This implementation is needed in order to have more control
+    # over the layout/format of the hoverdata
+    # The Plotly Express choropleth does not seem to provide a hook
+    # into the underlying hover template in the same way that the
+    # low level Graph Objects API does
 
+    # first create a plain Figure object
+    choropleth = go.Figure()
+
+    # loop over all categories and add a separate trace for each one
+    for i, category in enumerate(dff['Category'].unique()):
+        # filter dataset to only include data for current category
+        dff_subset = dff[dff['Category'] == category]
+        trace = go.Choropleth(
+            locations=dff_subset['name'],
+            locationmode='country names',
+            z=[i,] * len(dff_subset), # meant to specify color, constant
+            name=category, # name each trace by the category for reference
+            colorscale=(
+                (0.0, color_dictionary[category]),
+                (1.0, color_dictionary[category])
+            ), # strange colorscale construction, but just maps to the dict
+            customdata=np.stack((
+                dff_subset['Percentage'], 
+                dff_subset['Category'],
+                dff_subset['name'],
+                dff_subset['URL']
+            ), axis=-1), # custom data so we can customize the hover template
+            showscale=False,
+            hovertemplate='<br>'.join([
+                '<b>%{customdata[2]}</b>',
+                '%{customdata[1]}',
+                'Percent of Imports: %{customdata[0]}%',
+            ]) + '<extra></extra>' # specifies what data gets shown and how
+        )
+
+        # add the trace to the choropleth figure
+        choropleth.add_trace(trace)
+
+    # update the layout to set margins and title
+    choropleth.update_layout(
+        margin=dict(l=30, r=30, t=50, b=20), # adjust these to shrink/expand
+        title=f'Countries of import for {metal_value}'
+    )
 
     dff2 = df.loc[
         (df["Metal"] == metal_value) & (df["Subcategory"] == subcategory)]
@@ -83,6 +131,32 @@ def update_graph(metal_value, subcategory):
         hole=.3)
 
     return choropleth, piechart
+
+
+# updates the hover link component with link to URL
+# of page containing info about Country relations
+@app.callback(
+    Output('hover_link', 'children'),
+    [Input('the_graph', 'hoverData')]
+)
+def handle_choropleth_hover(hover_data):
+    print(hover_data)
+    if hover_data is None:
+        return 'Hover over countries to learn more'
+    else:
+        country_name = hover_data['points'][0]['location']
+        category = hover_data['points'][0]['customdata'][1]
+        link = html.A(
+            children=f'Learn More about U.S. relations with {country_name}',
+            href=hover_data['points'][0]['customdata'][3],
+            target='_blank', # open in a new tab
+            style={
+                'textDecoration': 'underline',
+                'color': color_dictionary[category]
+            }
+        )
+        return link
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I have made the following additions/changes to the dashboard in a separate branch. The changes are as follows.

1. Added imports for `plotly.graph_objects` (low level graphing API) and numpy to support added functionality
2. In the app layout, added an `html.H4` element to render a link to the page on the U.S. Department of State website describing U.S. relations with the country that the user hovers over on the Choropleth.
3. Changed the implementation of the choropleth map in the `update_graph()` callback to use the bare-bones `go.Figure()` class with custom choropleth traces added to the figure. This allows us to have more control over the hover tooltip formatting and data rendering via the `hovertemplate` keyword argument that `go.Choropleth` takes in. The code here is quite a bit more complex, so feel free to ask me questions about it. I don't fully understand the ins/outs of it, but I adapted this code from an example I found elsewhere in the Plotly Q&A forums
4. Added a new callback `handle_choropleth_hover` to implement the functionality where when a user hovers over a country on the map, the text below the map updates to render a link to the U.S. Department of State relations description. Plotly enables you to write callbacks to respond to hover events on any `dcc.Graph()` that take in the hoverData argument. You can then do arbitrary things with that hover data, such as populate UI elements as is done in this example.

Please review and let me know if you have any questions, or would like to meet to discuss incorporating/merging these changes into your main branch.

Cheers.

